### PR TITLE
Do not require parens for `defeffect`

### DIFF
--- a/lib/efx.ex
+++ b/lib/efx.ex
@@ -167,6 +167,7 @@ defmodule Efx do
 
   defmacro defeffect(fun, do_block) do
     {name, ctx, args} = fun
+    args = ensure_list(args)
     module = __CALLER__.module
 
     # we do this to not get warnings for wildcard params in functions
@@ -216,10 +217,16 @@ defmodule Efx do
   end
 
   @spec spec_name({any(), any(), list()}) :: name :: atom()
-  defp spec_name({_, _, a}), do: List.first(a) |> elem(0)
+  defp spec_name({_, _, a}) do
+    a = ensure_list(a)
+    List.first(a) |> elem(0)
+  end
 
   @spec spec_arity(tuple()) :: arity()
-  defp spec_arity({:"::", _, [{_, _, args} | _]}), do: Enum.count(args)
+  defp spec_arity({:"::", _, [{_, _, args} | _]}) do
+    args = ensure_list(args)
+    Enum.count(args)
+  end
 
   @spec already_exists?(module(), atom(), arity()) :: boolean()
   def already_exists?(module, name, arity) do
@@ -230,4 +237,8 @@ defmodule Efx do
       end
     )
   end
+
+  @spec ensure_list(list() | nil) :: list()
+  defp ensure_list(nil), do: []
+  defp ensure_list(list), do: list
 end

--- a/test/efx_case_global_test.exs
+++ b/test/efx_case_global_test.exs
@@ -63,4 +63,10 @@ defmodule EfxCaseGlobalTest do
       assert [] = TestAgent.get()
     end
   end
+
+  describe "style" do
+    test "zero-artity may be defined without parens" do
+      assert EfxExample.without_parens() == :ok
+    end
+  end
 end

--- a/test/support/efx_example.ex
+++ b/test/support/efx_example.ex
@@ -28,4 +28,9 @@ defmodule EfxCase.EfxExample do
   defeffect multi_fun(string) do
     string
   end
+
+  @spec without_parens :: atom
+  defeffect without_parens do
+    :ok
+  end
 end


### PR DESCRIPTION
I got curious and wanted to play around and was able to make `defeffect` work without requiring parens.  No worries if you want to close (or re-implement) but I think it would be nice for those who follow it to be able to stay consistent.

Also just FYI, there is a bunch of trailing whitespace `lib/efx.ex` which makes diffing a pain when you have a strip-whitespace enabled editor.

Fixes #1 