### PR TITLE
Fix a typo in an assertion

### DIFF
--- a/lib/efx_case/mock_state.ex
+++ b/lib/efx_case/mock_state.ex
@@ -54,7 +54,7 @@ defmodule EfxCase.MockState do
       end)
 
     if result == {:error, :function_not_in_mock} do
-      Assertions.flunk("Not matching function found for #{behaviour}: #{fun_identifier}/#{arity}")
+      Assertions.flunk("No matching function found for #{behaviour}: #{fun_identifier}/#{arity}")
     end
 
     :ok


### PR DESCRIPTION
Small chance that it's by design, but I think it's a typo: `Not matching [...]` -> `No matching`.

```
  1) test immediately refreshes expired tokens (Twitch.AuthTest)
     test/twitch/auth_test.exs:21
     Not matching function found for Elixir.Twitch.Auth.Effect: refresh_token/3
     code: bind(Effect, :refresh_token, fn _, _, _ ->
     stacktrace:
       (efx 0.2.11) lib/efx_case/mock_state.ex:57: EfxCase.MockState.add_fun/6
       test/twitch/auth_test.exs:34: (test)
```